### PR TITLE
fix for file chooser filter

### DIFF
--- a/QuickViewer/src/mainwindow.cpp
+++ b/QuickViewer/src/mainwindow.cpp
@@ -1305,7 +1305,7 @@ void MainWindow::onActionTurnPageOnRight_triggered()
 
 void MainWindow::onActionOpenfolder_triggered()
 {
-    QString filter = tr("All Files( *.*);;Images (*.jpg *.jpeg *.png *.tif *.tiff *.ico);;Archives( *.zip *.7z *.rar)", "Text that specifies the file extension to be displayed when opening a file with OpenFileFolder");
+    QString filter = tr("All Files( *.* );;Images ( *.jpg *.jpeg *.png *.tif *.tiff *.ico);;Archives( *.zip *.7z *.rar)", "Text that specifies the file extension to be displayed when opening a file with OpenFileFolder");
     QString folder = QFileDialog::getOpenFileName(
                 this,
                 tr("Please select the image or archive", "Title of the dialog displayed when opening a file with OpenFileFolder"),


### PR DESCRIPTION
There is a bug in filechooser's filter, at least on mac.

### before

![images_filter_all](https://user-images.githubusercontent.com/975883/43110802-472cefd0-8eee-11e8-908a-2bb66e9089de.png)
![images_filter_mac](https://user-images.githubusercontent.com/975883/43110803-488efdc8-8eee-11e8-86fe-5582016fa883.png)

### after

![after](https://user-images.githubusercontent.com/975883/43111722-bd273908-8ef2-11e8-8136-f762d17c9fc7.png)
![after2](https://user-images.githubusercontent.com/975883/43111723-bec74d16-8ef2-11e8-881a-eae5daaaa218.png)

Adding a space betweeen "(" and "*") fix that (qt?) bug.