### PR TITLE
Mac cosmetic fixes

### DIFF
--- a/QuickViewer/Info.plist
+++ b/QuickViewer/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleName</key>
-        <string>QuickViewer-@FULL_VERSION@</string>
+        <string>QuickViewer</string>
 	<key>CFBundleDisplayName</key>
         <string>QuickViewer-@FULL_VERSION@</string>
 	<key>NSPrincipalClass</key>

--- a/QuickViewer/src/main.cpp
+++ b/QuickViewer/src/main.cpp
@@ -26,7 +26,13 @@ int main(int argc, char *argv[])
         if(::lstrcmp(value, L"true")==0)
             qputenv("QT_QPA_PLATFORM", "direct2d");
     }
+#elif defined(Q_OS_MAC)
+    {
+        // hide icons on application menu.
+        QApplication::instance()->setAttribute(Qt::AA_DontShowIconsInMenus, true);
+    }
 #endif
+
     QVApplication app(argc, argv);
 
     app.myInstallTranslator();


### PR DESCRIPTION
Don't display app version on menubar. CFBundleDisplayName is left untouched so the window title still includes application version.

Hide icons on mac menubar.