### PR TITLE
use specific action roles instead of text heuristic roles

### DIFF
--- a/QuickViewer/src/mainwindow.cpp
+++ b/QuickViewer/src/mainwindow.cpp
@@ -49,6 +49,12 @@ MainWindow::MainWindow(QWidget *parent)
 
 #ifdef Q_OS_MACOS
     ui->menuBar->setNativeMenuBar(true);
+    ui->actionOpenOptionsDialog->setMenuRole(QAction::PreferencesRole);
+    ui->actionAppVersion->setMenuRole(QAction::AboutRole);
+    ui->actionExit->setMenuRole(QAction::QuitRole);
+    ui->actionOpenKeyConfig->setMenuRole(QAction::NoRole);
+    ui->actionOpenMouseConfig->setMenuRole(QAction::NoRole);
+    ui->actionCheckVersion->setMenuRole(QAction::ApplicationSpecificRole);
 #endif
 
 	m_fullscreenButton = new QToolButton(this);


### PR DESCRIPTION
by default Qt on mac tries to populate the 'native' application menu with - at least -
the action for preferences, and the action for quit. It also tries to find the 'about' and 'aboutQt'
actions - if any.

Those text heuristics can clash on some circunstances e.g: having 2 or more actions called SettingsSomething - or even worst - having 2 or more actions named with different names but with the same translation string.

This commit replaces the default TextHeuristicMenuRole by specific common actions. (about, quit, preferences, keyboard & mouse preferences..)

### preview of the application menu - in spanish.
![ba](https://user-images.githubusercontent.com/975883/43233257-51f5d3e0-9075-11e8-9069-80b92f6062e0.png)

### preview of the help menu - in spanish.
![be](https://user-images.githubusercontent.com/975883/43233266-5f4ea972-9075-11e8-8e14-39033b6db2cb.png)

also, please consider using the [Sparkle framework](https://sparkle-project.org/) and [winsparkle](https://winsparkle.org/) for providing in-app update capabilities on mac and windows.

I never used winsparkle but sparkle for mac can be easily integrated on qt applications.