### PR TITLE
Store configuration files in a subdirectory

### DIFF
--- a/HowToBuild.md
+++ b/HowToBuild.md
@@ -122,7 +122,7 @@ $ ln -s ../../quickviewer/QuickViewer/translations translations
 
 ### For Windows
 
-- **[database]**
+- **[config/database]** or **[database]**
     - SQLite database which contains Catalogs and thumbnails
 - **[shaders]**
     - Fragment Shaders for image resizing (obsolete)
@@ -132,11 +132,16 @@ $ ln -s ../../quickviewer/QuickViewer/translations translations
     - Application main
 - **AssociateFilesWithQuickViewer.exe**
     - Set the association of image formats with UAC
-- **quickviewer.ini**
+- **[config/quickviewer.ini]** or **[quickviewer.ini]**
     - Main configuration file. Includes keyboard and mouse settings
-- **progress.ini**
+- **[config/progress.ini]** or **[progress.ini]**
     - Record the last displayed image in volume.
 
+The versions with **config** subdirectory are preferred due to their
+better security properties - the directory may be made writable without
+allowing modifications to the binary files. However, since they break
+compatibility with current installations, they are only used if the
+directory exists.
 
 ### For Linux (.AppImage)
 

--- a/QuickViewer/src/main.cpp
+++ b/QuickViewer/src/main.cpp
@@ -20,6 +20,10 @@ int main(int argc, char *argv[])
         // it must be set to the QT_QPA_PLATFORM environment variable before that.
 #  ifdef QV_PORTABLE
         QString inipath = QDir::toNativeSeparators(QFileInfo(argv[0]).path());
+        QDir iniSubDir = QDir(inipath + "\\" CONFIG_SUBDIR);
+        if (iniSubDir.exists()) {
+        	inipath += "\\" CONFIG_SUBDIR;
+        }
         inipath += "\\" APP_INI;
 #  else
         QString inipath = QDir(QStandardPaths::writableLocation(QStandardPaths::DataLocation)).filePath(APP_INI);

--- a/QuickViewer/src/models/qvapplication.cpp
+++ b/QuickViewer/src/models/qvapplication.cpp
@@ -96,6 +96,10 @@ QString QVApplication::getFilePathOfApplicationSetting(QString subFilePath)
 {
 #ifdef Q_OS_WIN
     if(m_portable) {
+        QDir settingsSubDir = getApplicationFilePath(QString("%1/" CONFIG_SUBDIR).arg(subFilePath));
+        if (settingsSubDir.exists()) {
+            return settingsSubDir;
+        }
         return getApplicationFilePath(subFilePath);
     } else {
         return QDir(QStandardPaths::writableLocation(QStandardPaths::DataLocation)).filePath(subFilePath);

--- a/QuickViewer/src/qv_init.h
+++ b/QuickViewer/src/qv_init.h
@@ -9,6 +9,7 @@
 #define QV_THUMBNAILS "thumbnail.sqlite3.db"
 
 #ifdef Q_OS_WIN
+#define CONFIG_SUBDIR "config"
 #define APP_INI "quickviewer.ini"
 #define PROGRESS_INI "progress.ini"
 #define LINEFEED "\r\n"


### PR DESCRIPTION
The is preferred due to the better security properties - the directory may be made writable without allowing modifications to the binary files. However, since this breaks compatibility with current installations, it is only used if the
directory exists. Otherwise the original behavior (config files directly next to the main binary files) is used.