### PR TITLE
Potential Vulnerability in Cloned Code

### DIFF
--- a/unrar/unrar/arccmt.cpp
+++ b/unrar/unrar/arccmt.cpp
@@ -111,7 +111,7 @@ bool Archive::GetComment(Array<wchar> *CmtData)
     // 4x memory for OEM to UTF-8 output here.
     OemToCharA((char *)&CmtRaw[0],(char *)&CmtRaw[0]);
 #endif
-    CharToWide((char *)&CmtRaw[0],CmtData->Addr(0),CmtLength);
+    CharToWide((char *)&CmtRaw[0],CmtData->Addr(0),CmtData->Size());
     CmtData->Alloc(wcslen(CmtData->Addr(0)));
   }
 #endif

--- a/unrar/unrar/archive.hpp
+++ b/unrar/unrar/archive.hpp
@@ -55,6 +55,10 @@ class Archive:public File
     bool SilentOpen;
 #ifdef USE_QOPEN
     QuickOpen QOpen;
+    bool ProhibitQOpen;
+#endif
+#ifdef USE_ARCMEM
+    ArcMemory ArcMem;
 #endif
   public:
     Archive(RAROptions *InitCmd=NULL);
@@ -89,12 +93,15 @@ class Archive:public File
 #if 0
     void GetRecoveryInfo(bool Required,int64 *Size,int *Percent);
 #endif
-#ifdef USE_QOPEN
     bool Open(const wchar *Name,uint Mode=FMF_READ);
+    bool Close();
     int Read(void *Data,size_t Size);
     void Seek(int64 Offset,int Method);
     int64 Tell();
+    bool IsOpened();
+#ifdef USE_QOPEN
     void QOpenUnload() {QOpen.Unload();}
+    void SetProhibitQOpen(bool Mode) {ProhibitQOpen=Mode;}
 #endif
 
     BaseBlock ShortBlock;

--- a/unrar/unrar/arcmem.cpp
+++ b/unrar/unrar/arcmem.cpp
@@ -1,0 +1,62 @@
+ArcMemory::ArcMemory()
+{
+  Loaded=false;
+  SeekPos=0;
+}
+
+
+void ArcMemory::Load(const byte *Data,size_t Size)
+{
+  ArcData.Alloc(Size);
+  memcpy(&ArcData[0],Data,Size);
+  Loaded=true;
+  SeekPos=0;
+}
+
+
+bool ArcMemory::Unload()
+{
+  if (!Loaded)
+    return false;
+  Loaded=false;
+  return true;
+}
+
+
+bool ArcMemory::Read(void *Data,size_t Size,size_t &Result)
+{
+  if (!Loaded)
+    return false;
+  Result=(size_t)Min(Size,ArcData.Size()-SeekPos);
+  memcpy(Data,&ArcData[(size_t)SeekPos],Result);
+  SeekPos+=Result;
+  return true;
+}
+
+
+bool ArcMemory::Seek(int64 Offset,int Method)
+{
+  if (!Loaded)
+    return false;
+  if (Method==SEEK_SET)
+    SeekPos=Min(Offset,ArcData.Size());
+  else
+    if (Method==SEEK_CUR || Method==SEEK_END)
+    {
+      if (Method==SEEK_END)
+        SeekPos=ArcData.Size();
+      SeekPos+=(uint64)Offset;
+      if (SeekPos>ArcData.Size())
+        SeekPos=Offset<0 ? 0 : ArcData.Size();
+    }
+  return true;
+}
+
+
+bool ArcMemory::Tell(int64 *Pos)
+{
+  if (!Loaded)
+    return false;
+  *Pos=SeekPos;
+  return true;
+}

--- a/unrar/unrar/arcmem.hpp
+++ b/unrar/unrar/arcmem.hpp
@@ -1,0 +1,22 @@
+#ifndef _RAR_ARCMEM_
+#define _RAR_ARCMEM_
+
+// Memory interface for software fuzzers.
+
+class ArcMemory
+{
+  private:
+    bool Loaded;
+    Array<byte> ArcData;
+    uint64 SeekPos;
+  public:
+    ArcMemory();
+    void Load(const byte *Data,size_t Size);
+    bool Unload();
+    bool IsLoaded() {return Loaded;}
+    bool Read(void *Data,size_t Size,size_t &Result);
+    bool Seek(int64 Offset,int Method);
+    bool Tell(int64 *Pos);
+};
+
+#endif

--- a/unrar/unrar/arcread.cpp
+++ b/unrar/unrar/arcread.cpp
@@ -734,7 +734,7 @@ size_t Archive::ReadHeader50()
           ProcessExtra50(&Raw,(size_t)ExtraSize,&MainHead);
 
 #ifdef USE_QOPEN
-        if (MainHead.Locator && MainHead.QOpenOffset>0 && Cmd->QOpenMode!=QOPEN_NONE)
+        if (!ProhibitQOpen && MainHead.Locator && MainHead.QOpenOffset>0 && Cmd->QOpenMode!=QOPEN_NONE)
         {
           // We seek to QO block in the end of archive when processing
           // QOpen.Load, so we need to preserve current block positions
@@ -1070,7 +1070,7 @@ void Archive::ProcessExtra50(RawRead *Raw,size_t ExtraSize,BaseBlock *bb)
 
               wchar VerText[20];
               swprintf(VerText,ASIZE(VerText),L";%u",Version);
-              wcsncatz(FileHead.FileName,VerText,ASIZE(FileHead.FileName));
+              wcsncatz(hd->FileName,VerText,ASIZE(hd->FileName));
             }
           }
           break;

--- a/unrar/unrar/cmddata.cpp
+++ b/unrar/unrar/cmddata.cpp
@@ -96,7 +96,7 @@ void CommandData::ParseArg(wchar *Arg)
   else
     if (*Command==0)
     {
-      wcsncpy(Command,Arg,ASIZE(Command));
+      wcsncpyz(Command,Arg,ASIZE(Command));
 
 
       *Command=toupperw(*Command);
@@ -1208,8 +1208,8 @@ int CommandData::IsProcessFile(FileHeader &FileHead,bool *ExactMatch,int MatchTy
 {
   if (MatchedArg!=NULL && MatchedArgSize>0)
     *MatchedArg=0;
-  if (wcslen(FileHead.FileName)>=NM)
-    return 0;
+//  if (wcslen(FileHead.FileName)>=NM)
+//    return 0;
   bool Dir=FileHead.Dir;
   if (ExclCheck(FileHead.FileName,Dir,false,true))
     return 0;
@@ -1267,7 +1267,7 @@ void CommandData::ProcessCommand()
       wcsncpyz(ArcName,Name,ASIZE(ArcName));
   }
 
-  if (wcschr(L"AFUMD",*Command)==NULL)
+  if (wcschr(L"AFUMD",*Command)==NULL && !ArcInMem)
   {
     if (GenerateArcName)
       GenerateArchiveName(ArcName,ASIZE(ArcName),GenerateMask,false);

--- a/unrar/unrar/compress.hpp
+++ b/unrar/unrar/compress.hpp
@@ -6,7 +6,16 @@
 class PackDef
 {
   public:
+    // Maximum LZ match length we can encode even for short distances.
     static const uint MAX_LZ_MATCH = 0x1001;
+
+    // We increment LZ match length for longer distances, because shortest
+    // matches are not allowed for them. Maximum length increment is 3
+    // for distances larger than 256KB (0x40000). Here we define the maximum
+    // incremented LZ match. Normally packer does not use it, but we must be
+    // ready to process it in corrupt archives.
+    static const uint MAX_INC_LZ_MATCH = MAX_LZ_MATCH + 3;
+
     static const uint MAX3_LZ_MATCH = 0x101; // Maximum match length for RAR v3.
     static const uint LOW_DIST_REP_COUNT = 16;
 

--- a/unrar/unrar/file.hpp
+++ b/unrar/unrar/file.hpp
@@ -75,7 +75,7 @@ class File
     bool Create(const wchar *Name,uint Mode=FMF_UPDATE|FMF_SHAREREAD);
     void TCreate(const wchar *Name,uint Mode=FMF_UPDATE|FMF_SHAREREAD);
     bool WCreate(const wchar *Name,uint Mode=FMF_UPDATE|FMF_SHAREREAD);
-    bool Close();
+    virtual bool Close();
     bool Delete();
     bool Rename(const wchar *NewName);
     bool Write(const void *Data,size_t Size);
@@ -93,7 +93,7 @@ class File
     void SetCloseFileTime(RarTime *ftm,RarTime *fta=NULL);
     static void SetCloseFileTimeByName(const wchar *Name,RarTime *ftm,RarTime *fta);
     void GetOpenFileTime(RarTime *ft);
-    bool IsOpened() {return hFile!=FILE_BAD_HANDLE;};
+    virtual bool IsOpened() {return hFile!=FILE_BAD_HANDLE;};
     int64 FileLength();
     void SetHandleType(FILE_HANDLETYPE Type) {HandleType=Type;}
     FILE_HANDLETYPE GetHandleType() {return HandleType;}

--- a/unrar/unrar/makefile
+++ b/unrar/unrar/makefile
@@ -3,7 +3,7 @@
 
 # Linux using GCC
 CXX=c++
-CXXFLAGS=-O2
+CXXFLAGS=-O2 -Wno-logical-op-parentheses -Wno-switch -Wno-dangling-else
 LIBFLAGS=-fPIC
 DEFINES=-D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -DRAR_SMP
 STRIP=strip

--- a/unrar/unrar/options.hpp
+++ b/unrar/unrar/options.hpp
@@ -85,10 +85,24 @@ class RAROptions
     bool InclAttrSet;
     size_t WinSize;
     wchar TempPath[NM];
-#ifdef USE_QOPEN
     wchar SFXModule[NM];
+
+#ifdef USE_QOPEN
     QOPEN_MODE QOpenMode;
 #endif
+
+    bool ArcInMem;
+#ifdef USE_ARCMEM
+    void SetArcInMem(byte *Data,size_t Size)
+    {
+      ArcMemData=Data;
+      ArcMemSize=Size;
+      ArcInMem=Data!=NULL && Size>0;
+    }
+    byte *ArcMemData;
+    size_t ArcMemSize;
+#endif
+
     bool ConfigDisabled; // Switch -cfg-.
     wchar ExtrPath[NM];
     wchar CommentFile[NM];

--- a/unrar/unrar/qopen.cpp
+++ b/unrar/unrar/qopen.cpp
@@ -61,14 +61,27 @@ void QuickOpen::Close()
 
 void QuickOpen::Load(uint64 BlockPos)
 {
-  if (!Loaded) // If loading the first time, perform additional intialization.
+  if (!Loaded)
   {
+    // If loading for the first time, perform additional intialization.
     SeekPos=Arc->Tell();
     UnsyncSeekPos=false;
 
     SaveFilePos SavePos(*Arc);
     Arc->Seek(BlockPos,SEEK_SET);
-    if (Arc->ReadHeader()==0 || Arc->GetHeaderType()!=HEAD_SERVICE ||
+
+    // If BlockPos points to original main header, we'll have the infinite
+    // recursion, because ReadHeader() for main header will attempt to load
+    // QOpen and call QuickOpen::Load again. If BlockPos points to long chain
+    // of other main headers, we'll have multiple recursive calls of this
+    // function wasting resources. So we prohibit QOpen temporarily to
+    // prevent this. ReadHeader() calls QOpen.Init and sets MainHead Locator
+    // and QOpenOffset fields, so we cannot use them to prohibit QOpen.
+    Arc->SetProhibitQOpen(true);
+    size_t ReadSize=Arc->ReadHeader();
+    Arc->SetProhibitQOpen(false);
+
+    if (ReadSize==0 || Arc->GetHeaderType()!=HEAD_SERVICE ||
         !Arc->SubHead.CmpName(SUBHEAD_TYPE_QOPEN))
       return;
     QLHeaderPos=Arc->CurBlockPos;

--- a/unrar/unrar/rar.cpp
+++ b/unrar/unrar/rar.cpp
@@ -76,6 +76,13 @@ int main(int argc, char *argv[])
     ErrHandler.SetSilent(Cmd->AllYes || Cmd->MsgStream==MSG_NULL);
 
     Cmd->OutTitle();
+/*
+    byte Buf[10000];
+    File Src;
+    Src.TOpen(L"123.rar");
+    int Size=Src.Read(Buf,sizeof(Buf));
+    Cmd->SetArcInMem(Buf,Size);
+*/
     Cmd->ProcessCommand();
     delete Cmd;
   }

--- a/unrar/unrar/rar.hpp
+++ b/unrar/unrar/rar.hpp
@@ -42,6 +42,9 @@
 #ifdef USE_QOPEN
 #include "qopen.hpp"
 #endif
+#ifdef USE_ARCMEM
+#include "arcmem.hpp"
+#endif
 #include "archive.hpp"
 #include "match.hpp"
 #include "cmddata.hpp"

--- a/unrar/unrar/rardefs.hpp
+++ b/unrar/unrar/rardefs.hpp
@@ -24,6 +24,7 @@
 #ifndef SFX_MODULE
 #define USE_QOPEN
 #endif
+#define USE_ARCMEM
 
 // Produce the value, which is equal or larger than 'v' and aligned to 'a'.
 #define ALIGN_VALUE(v,a) (size_t(v) + ( (~size_t(v) + 1) & (a - 1) ) )

--- a/unrar/unrar/recvol5.cpp
+++ b/unrar/unrar/recvol5.cpp
@@ -139,8 +139,12 @@ bool RecVolumes5::Restore(RAROptions *Cmd,const wchar *Name,bool Silent)
   wcsncpyz(ArcName,Name,ASIZE(ArcName));
 
   wchar *Num=GetVolNumPart(ArcName);
+  if (Num==ArcName)
+    return false; // Number part is missing in the name.
   while (Num>ArcName && IsDigit(*(Num-1)))
     Num--;
+  if (Num==ArcName)
+    return false; // Entire volume name is numeric, not possible for REV file.
   wcsncpyz(Num,L"*.*",ASIZE(ArcName)-(Num-ArcName));
   
   wchar FirstVolName[NM];

--- a/unrar/unrar/unicode.cpp
+++ b/unrar/unrar/unicode.cpp
@@ -142,7 +142,7 @@ bool WideToCharMap(const wchar *Src,char *Dest,size_t DestSize,bool &Success)
     {
       mbstate_t ps;
       memset(&ps,0,sizeof(ps));
-      if (wcrtomb(Dest+DestPos,Src[SrcPos],&ps)==-1)
+      if (wcrtomb(Dest+DestPos,Src[SrcPos],&ps)==(size_t)-1)
         Success=false;
       SrcPos++;
       memset(&ps,0,sizeof(ps));
@@ -176,7 +176,8 @@ void CharToWideMap(const char *Src,wchar *Dest,size_t DestSize,bool &Success)
     }
     mbstate_t ps;
     memset(&ps,0,sizeof(ps));
-    if (mbrtowc(Dest+DestPos,Src+SrcPos,MB_CUR_MAX,&ps)==-1)
+    size_t res=mbrtowc(Dest+DestPos,Src+SrcPos,MB_CUR_MAX,&ps);
+    if (res==(size_t)-1 || res==(size_t)-2)
     {
       // For security reasons we do not want to map low ASCII characters,
       // so we do not have additional .. and path separator codes.

--- a/unrar/unrar/unpack.hpp
+++ b/unrar/unrar/unpack.hpp
@@ -316,7 +316,7 @@ class Unpack:PackDef
     bool ReadEndOfBlock();
     bool ReadVMCode();
     bool ReadVMCodePPM();
-    bool AddVMCode(uint FirstByte,byte *Code,int CodeSize);
+    bool AddVMCode(uint FirstByte,byte *Code,uint CodeSize);
     int SafePPMDecodeChar();
     bool ReadTables30();
     bool UnpReadBuf30();

--- a/unrar/unrar/unpack30.cpp
+++ b/unrar/unrar/unpack30.cpp
@@ -354,7 +354,7 @@ bool Unpack::ReadVMCodePPM()
 }
 
 
-bool Unpack::AddVMCode(uint FirstByte,byte *Code,int CodeSize)
+bool Unpack::AddVMCode(uint FirstByte,byte *Code,uint CodeSize)
 {
   VMCodeInp.InitBitInput();
   memcpy(VMCodeInp.InBuf,Code,Min(BitInput::MAX_SIZE,CodeSize));
@@ -466,7 +466,7 @@ bool Unpack::AddVMCode(uint FirstByte,byte *Code,int CodeSize)
   if (NewFilter)
   {
     uint VMCodeSize=RarVM::ReadData(VMCodeInp);
-    if (VMCodeSize>=0x10000 || VMCodeSize==0)
+    if (VMCodeSize>=0x10000 || VMCodeSize==0 || VMCodeInp.InAddr+VMCodeSize>CodeSize)
       return false;
     Array<byte> VMCode(VMCodeSize);
     for (uint I=0;I<VMCodeSize;I++)

--- a/unrar/unrar/unpack50.cpp
+++ b/unrar/unrar/unpack50.cpp
@@ -37,7 +37,7 @@ void Unpack::Unpack5(bool Solid)
         break;
     }
 
-    if (((WriteBorder-UnpPtr) & MaxWinMask)<MAX_LZ_MATCH+3 && WriteBorder!=UnpPtr)
+    if (((WriteBorder-UnpPtr) & MaxWinMask)<MAX_INC_LZ_MATCH && WriteBorder!=UnpPtr)
     {
       UnpWriteBuf();
       if (WrittenFileSize>DestUnpSize)

--- a/unrar/unrar/unpack50mt.cpp
+++ b/unrar/unrar/unpack50mt.cpp
@@ -449,7 +449,7 @@ bool Unpack::ProcessDecoded(UnpackThreadData &D)
   while (Item<Border)
   {
     UnpPtr&=MaxWinMask;
-    if (((WriteBorder-UnpPtr) & MaxWinMask)<MAX_LZ_MATCH+3 && WriteBorder!=UnpPtr)
+    if (((WriteBorder-UnpPtr) & MaxWinMask)<MAX_INC_LZ_MATCH && WriteBorder!=UnpPtr)
     {
       UnpWriteBuf();
       if (WrittenFileSize>DestUnpSize)
@@ -557,7 +557,7 @@ bool Unpack::UnpackLargeBlock(UnpackThreadData &D)
         break;
       }
     }
-    if (((WriteBorder-UnpPtr) & MaxWinMask)<MAX_LZ_MATCH+3 && WriteBorder!=UnpPtr)
+    if (((WriteBorder-UnpPtr) & MaxWinMask)<MAX_INC_LZ_MATCH && WriteBorder!=UnpPtr)
     {
       UnpWriteBuf();
       if (WrittenFileSize>DestUnpSize)

--- a/unrar/unrar/unpackinline.cpp
+++ b/unrar/unrar/unpackinline.cpp
@@ -13,7 +13,7 @@ _forceinline void Unpack::InsertOldDist(uint Distance)
 _forceinline void Unpack::CopyString(uint Length,uint Distance)
 {
   size_t SrcPtr=UnpPtr-Distance;
-  if (SrcPtr<MaxWinSize-MAX_LZ_MATCH && UnpPtr<MaxWinSize-MAX_LZ_MATCH)
+  if (SrcPtr<MaxWinSize-MAX_INC_LZ_MATCH && UnpPtr<MaxWinSize-MAX_INC_LZ_MATCH)
   {
     // If we are not close to end of window, we do not need to waste time
     // to "& MaxWinMask" pointer protection.
@@ -46,7 +46,7 @@ _forceinline void Unpack::CopyString(uint Length,uint Distance)
       {
         // In theory we still could overlap here.
         // Supposing Distance == MaxWinSize - 1 we have memcpy(Src, Src + 1, 8).
-        // But for real RAR archives Distance <= MaxWinSize - MAX_LZ_MATCH
+        // But for real RAR archives Distance <= MaxWinSize - MAX_INC_LZ_MATCH
         // always, so overlap here is impossible.
 
         // This memcpy expanded inline by MSVC. We could also use uint64


### PR DESCRIPTION
### Summary
Our tool detected a potential vulnerability in unrar/unrar/recvol5.cpp which was cloned from aawc/unrar but did not receive the security patch applied. The original issue was reported and fixed under https://nvd.nist.gov/vuln/detail/cve-2017-20006.

### Proposed Fix
Apply the same patch as the one in aawc/unrar to eliminate the vulnerability.

### Reference
https://nvd.nist.gov/vuln/detail/cve-2017-20006
https://github.com/aawc/unrar/commit/0ff832d31470471803b175cfff4e40c1b08ee779